### PR TITLE
Refactor: Improve plugin efficiency

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/service/PsiService.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/service/PsiService.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtTypeReference
+import java.util.concurrent.Executor
 
 /**
  * @author Enaium
@@ -45,4 +46,16 @@ interface PsiService {
     fun annotations(ktProperty: KtProperty): List<Annotation>
     fun type(ktTypeReference: KtTypeReference): Type
     fun receiver(ktLambdaExpression: KtLambdaExpression): KtClass?
+
+    suspend fun <T> readActionNonblockingCoroutine(
+        project: Project,
+        executor: Executor? = null,
+        block: () -> T
+    ): T
+
+    suspend fun <T> readActionSmartNonblockingCoroutine(
+        project: Project,
+        executor: Executor? = null,
+        block: () -> T
+    ): T
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/Log.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/Log.kt
@@ -18,6 +18,7 @@ package cn.enaium.jimmer.buddy.utility
 
 import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import java.io.ByteArrayOutputStream
 import java.io.PrintWriter
@@ -28,11 +29,15 @@ import java.time.format.DateTimeFormatter
  * @author Enaium
  */
 class Log(project: Project) : ConsoleViewImpl(project, true) {
+    private val logger = thisLogger()
+
     fun info(text: String) {
+        logger.info(text)
         print(log(text), ConsoleViewContentType.NORMAL_OUTPUT)
     }
 
     fun error(e: Throwable) {
+        logger.error(e)
         val out = ByteArrayOutputStream()
         val writer = PrintWriter(out)
         e.printStackTrace(writer)
@@ -41,6 +46,7 @@ class Log(project: Project) : ConsoleViewImpl(project, true) {
     }
 
     fun warn(text: String) {
+        logger.warn(text)
         print(log(text), ConsoleViewContentType.LOG_WARNING_OUTPUT)
     }
 

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/apt.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/apt.kt
@@ -308,7 +308,8 @@ fun Project.psiClassesToApt(
     val typeElementCaches = mutableMapOf<String, TypeElement>()
 
     psiClasses.forEach { psiClass ->
-        typeElementCaches[psiClass.qualifiedName!!] = psiClass.asTypeElement(typeElementCaches)
+        val qualifiedName = psiClass.qualifiedName ?: return@forEach
+        typeElementCaches[qualifiedName] = psiClass.asTypeElement(typeElementCaches)
     }
 
     val sources = mutableListOf<Source>()

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/utitlity.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/utitlity.kt
@@ -315,3 +315,9 @@ fun Project.toDtoFile(projectDir: Path, path: Path): DtoFile {
 }
 
 val jimmerAnnotationPrefix: String = Scalar::class.java.packageName
+
+internal suspend inline fun <T> Project.readActionSmartCoroutine(
+    crossinline block: () -> T
+): T {
+    return JimmerBuddy.Services.PSI.readActionSmartNonblockingCoroutine(this) { block() }
+}


### PR DESCRIPTION
此 PR 尝试改善 #161 中提及的运行效率问题

* 尝试缩小 PSI 读锁范围，~~并且将 APT/KSP 生成逻辑移出锁范围~~ APT/KSP 生成逻辑内包含对 PSI 的读取（TypeElement 之类的，APT/KSP 需要用的对象内部是懒调用的函数而非瞬时快照），必须加锁，这部分似乎无法在小范围修改内解决。因此锁的范围只缩小到了 `projects: Set<GenerateProject>` 中的每一个 project。
* 循环处理 projects 的过程改为并发。移除 `sourcesProcessJava` 中一个疑似重复的循环流程。
* 使用非阻塞的 nonblocking read action（2024.1之前为 `ReadAction.nonBlocking(...)`，之后为 `com.intellij.openapi.application.constrainedReadAction(...)` ） + coroutine 来代替原本的 `ReadAction.compute` 。
* 将 `asyncRefreshSources` 的操作移动到 PSI 读锁外。
* 清理了部分未使用 import 。

我参考的部分相关文档：
- [Threading Model](https://plugins.jetbrains.com/docs/intellij/threading-model.html#non-blocking-read-actions-api)
- [Coroutine Read Actions](https://plugins.jetbrains.com/docs/intellij/coroutine-read-actions.html#coroutine-read-actions-api)
- [Program Structure Interface (PSI)（与PSI相关的一些内容）](https://plugins.jetbrains.com/docs/intellij/psi.html)

> 个人观点：考虑到官方文档提及 PSI 非线程安全，且可能会过时，在进行 `psiClassesToApt` / `ktClassesToKsp` 时内部产生的 APT/KSP 伪类型 (`TypeElement`/`KSDeclaration` 们) 也行可以考虑改为加载 PSI 瞬时数据直接构建对象，而不是以懒加载形式引用 PSI 对象。这样可能会导致加载了部分未必一定会使用到的 PSI 属性，但是可以大范围减小 PSI 读锁范围，并且将 APT/KSP 的代码生成过程放在锁外，降低锁占用时间和重试次数与概率。
> 但是我对插件开发或 PSI 对象了解不多，不太确定这么想对不对 :P

提交内容测试情况：

- [x] Java/APT 项目测试
- [x] Kotlin/KSP 项目测试 
- [x] 其他方面的测试，比如看看会不会影响到其他功能（主要只修改了 JimmerBuddy 中的四个 process 函数，影响范围似乎不大）
- [ ] 确认在低性能电脑上的改进效果