### PR TITLE
feat: add @Transient navigation to resolver or generated implementation

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/insight/ImmutableLineMarkerProvider.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/insight/ImmutableLineMarkerProvider.kt
@@ -113,6 +113,13 @@ class ImmutableLineMarkerProvider : RelatedItemLineMarkerProvider() {
                                                 targets.addAll(psiClass.findMethodsByName(it, false))
                                             }
                                     }
+
+                                    if (method.hasTransientAnnotation()) {
+                                        element.findGeneratedClass()?.findMethodsByName(method.name, false)
+                                            ?.forEach { target ->
+                                                targets.add(target)
+                                            }
+                                    }
                                     nav.setTargets(targets)
                                 }
                                 .createLineMarkerInfo(it)
@@ -182,6 +189,13 @@ class ImmutableLineMarkerProvider : RelatedItemLineMarkerProvider() {
                                                     targets.add(it)
                                                 }
                                             }
+                                    }
+
+                                    val propertyName = property.name
+                                    if (property.hasTransientAnnotation() && propertyName != null) {
+                                        element.findGeneratedClass()?.findPropertyByName(propertyName)?.also { target ->
+                                            targets.add(target)
+                                        }
                                     }
                                     nav.setTargets(targets)
                                 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/insight/ImmutableLineMarkerProvider.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/insight/ImmutableLineMarkerProvider.kt
@@ -114,12 +114,7 @@ class ImmutableLineMarkerProvider : RelatedItemLineMarkerProvider() {
                                             }
                                     }
 
-                                    if (method.hasTransientAnnotation()) {
-                                        element.findGeneratedClass()?.findMethodsByName(method.name, false)
-                                            ?.forEach { target ->
-                                                targets.add(target)
-                                            }
-                                    }
+                                    targets.addAll(method.findTransientNavigationTargets())
                                     nav.setTargets(targets)
                                 }
                                 .createLineMarkerInfo(it)
@@ -191,12 +186,7 @@ class ImmutableLineMarkerProvider : RelatedItemLineMarkerProvider() {
                                             }
                                     }
 
-                                    val propertyName = property.name
-                                    if (property.hasTransientAnnotation() && propertyName != null) {
-                                        element.findGeneratedClass()?.findPropertyByName(propertyName)?.also { target ->
-                                            targets.add(target)
-                                        }
-                                    }
+                                    targets.addAll(property.findTransientNavigationTargets())
                                     nav.setTargets(targets)
                                 }
                                 .createLineMarkerInfo(it)

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/reference/JimmerReferenceContributor.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/reference/JimmerReferenceContributor.kt
@@ -45,5 +45,6 @@ class JimmerReferenceContributor : PsiReferenceContributor() {
         register.registerReferenceProvider(pattern, FormulaPsiReferenceProvider)
         register.registerReferenceProvider(pattern, FetchByPsiReferenceProvider)
         register.registerReferenceProvider(pattern, OrderedPropPsiReferenceProvider)
+        register.registerReferenceProvider(pattern, TransientPsiReferenceProvider)
     }
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/reference/TransientPsiReferenceProvider.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/reference/TransientPsiReferenceProvider.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Enaium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.enaium.jimmer.buddy.extensions.reference
+
+import cn.enaium.jimmer.buddy.JimmerBuddy
+import cn.enaium.jimmer.buddy.utility.PROP
+import cn.enaium.jimmer.buddy.utility.annotArgName
+import cn.enaium.jimmer.buddy.utility.annotName
+import cn.enaium.jimmer.buddy.utility.findSpringBeanTargets
+import cn.enaium.jimmer.buddy.utility.subMiddle
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ProcessingContext
+import org.babyfish.jimmer.sql.Transient
+
+/**
+ * @author Enaium
+ */
+object TransientPsiReferenceProvider : PsiReferenceProvider() {
+    override fun getReferencesByElement(
+        element: PsiElement,
+        context: ProcessingContext
+    ): Array<out PsiReference> {
+        if (element.annotName() != Transient::class.qualifiedName) {
+            return emptyArray()
+        }
+
+        if (element.annotArgName() != "ref") {
+            return emptyArray()
+        }
+
+        return arrayOf(Reference(element))
+    }
+
+    private class Reference(e: PsiElement) : PsiReferenceBase<PsiElement>(e) {
+        private val beanName = e.text.subMiddle("\"", "\"")
+        private val targets = e.project.findSpringBeanTargets(beanName)
+
+        override fun resolve(): PsiElement? {
+            return targets.firstOrNull()
+        }
+
+        override fun getVariants(): Array<out Any> {
+            return targets.map { target ->
+                LookupElementBuilder.create((target as? PsiNamedElement)?.name ?: beanName).withIcon(JimmerBuddy.Icons.PROP)
+            }.toTypedArray()
+        }
+    }
+}

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
@@ -18,9 +18,13 @@ package cn.enaium.jimmer.buddy.utility
 
 import cn.enaium.jimmer.buddy.JimmerBuddy
 import cn.enaium.jimmer.buddy.service.PsiService
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.intellij.psi.javadoc.PsiDocComment
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiUtil
 import com.intellij.psi.util.findParentOfType
 import org.babyfish.jimmer.Draft
@@ -35,6 +39,8 @@ import org.babyfish.jimmer.sql.kt.KSqlClient
 import org.babyfish.jimmer.sql.kt.ast.KExecutable
 import org.babyfish.jimmer.sql.kt.ast.query.KTypedRootQuery
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.idea.base.util.allScope
+import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.findPropertyByName
@@ -648,4 +654,45 @@ fun PsiClass.findIdMethod(): PsiMethod? {
 
 fun KtClass.findIdProperty(): KtProperty? {
     return getAllProperties().find { it.hasIdAnnotation() }
+}
+
+fun PsiClass.findGeneratedClass(): PsiClass? {
+    val qualifiedName = this.qualifiedName ?: return null
+    val scope = project.allScope()
+    val facade = JavaPsiFacade.getInstance(project)
+    val found = facade.findClass(qualifiedName, scope) ?: return null
+    if (found.containingFile?.virtualFile?.let { isGeneratedSourceFile(it) } == true) {
+        return found
+    }
+
+    val simpleName = qualifiedName.substringAfterLast('.')
+    val generatedFiles = FileTypeIndex.getFiles(JavaFileType.INSTANCE, GlobalSearchScope.projectScope(project))
+        .asSequence()
+        .filter { it.name == "$simpleName.java" && isGeneratedSourceFile(it) }
+    return generatedFiles.firstNotNullOfOrNull { virtualFile ->
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return@firstNotNullOfOrNull null
+        (psiFile as? PsiClassOwner)?.classes?.firstOrNull { it.qualifiedName == qualifiedName }
+    }
+}
+
+fun KtClass.findGeneratedClass(): KtClass? {
+    val fqName = this.fqName?.asString() ?: return null
+    val scope = project.allScope()
+    val allClasses = KotlinFullClassNameIndex[fqName, project, scope]
+    return allClasses.firstOrNull { ktClass ->
+        val virtualFile = ktClass.containingFile.virtualFile ?: return@firstOrNull false
+        isGeneratedSourceFile(virtualFile)
+    } as? KtClass
+}
+
+private fun isGeneratedSourceFile(virtualFile: VirtualFile): Boolean {
+    var current = virtualFile.toNioPath().parent
+    while (current != null) {
+        val name = current.fileName?.toString()
+        if (name == "generated" || name == "generated-sources") {
+            return true
+        }
+        current = current.parent
+    }
+    return false
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
@@ -19,12 +19,14 @@ package cn.enaium.jimmer.buddy.utility
 import cn.enaium.jimmer.buddy.JimmerBuddy
 import cn.enaium.jimmer.buddy.service.PsiService
 import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.intellij.psi.javadoc.PsiDocComment
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
 import com.intellij.psi.util.PsiUtil
 import com.intellij.psi.util.findParentOfType
 import org.babyfish.jimmer.Draft
@@ -259,6 +261,212 @@ fun KtProperty.hasToOneAnnotation(): Boolean {
 fun KtProperty.hasTransientAnnotation(): Boolean {
     return hasAnnotation(Transient::class)
 }
+
+fun PsiMethod.findTransientNavigationTargets(): List<PsiElement> {
+    if (!hasTransientAnnotation()) {
+        return emptyList()
+    }
+
+    val annotation = modifierList.annotations.find { annotation ->
+        annotation.hasQualifiedName(Transient::class.qualifiedName!!)
+    } ?: return emptyList()
+
+    val resolverTargets = annotation.findTransientResolverTargets()
+    if (resolverTargets.isNotEmpty()) {
+        return resolverTargets
+    }
+
+    val generatedClass = containingClass?.findGeneratedClass() ?: return emptyList()
+    return generatedClass.findMethodsByName(name, false).toList()
+}
+
+fun KtProperty.findTransientNavigationTargets(): List<PsiElement> {
+    if (!hasTransientAnnotation()) {
+        return emptyList()
+    }
+
+    val annotation = annotationEntries.find { entry ->
+        entry.toUElementOfType<UAnnotation>()?.qualifiedName == Transient::class.qualifiedName
+    } ?: return emptyList()
+
+    val resolverTargets = annotation.findTransientResolverTargets()
+    if (resolverTargets.isNotEmpty()) {
+        return resolverTargets
+    }
+
+    val propertyName = name ?: return emptyList()
+    val generatedClass = containingClass()?.findGeneratedClass() ?: return emptyList()
+    return listOfNotNull(generatedClass.findPropertyByName(propertyName))
+}
+
+private fun PsiAnnotation.findTransientResolverTargets(): List<PsiElement> {
+    val targets = mutableListOf<PsiElement>()
+    findClassAttributeTarget("value")?.also { target ->
+        targets.add(target)
+    }
+    findStringAttribute("ref")?.also { ref ->
+        targets.addAll(project.findSpringBeanTargets(ref))
+    }
+    return targets.distinct()
+}
+
+private fun KtAnnotationEntry.findTransientResolverTargets(): List<PsiElement> {
+    val targets = mutableListOf<PsiElement>()
+    findClassArgumentTarget("value")?.also { target ->
+        targets.add(target)
+    }
+    findStringArgument("ref")?.also { ref ->
+        targets.addAll(project.findSpringBeanTargets(ref))
+    }
+    return targets.distinct()
+}
+
+private fun PsiAnnotation.findClassAttributeTarget(attributeName: String): PsiClass? {
+    val value = findDeclaredAttributeValue(attributeName) ?: return null
+    return (value as? PsiClassObjectAccessExpression)?.operand?.type?.resolveClass()
+}
+
+private fun PsiAnnotation.findStringAttribute(attributeName: String): String? {
+    val value = findDeclaredAttributeValue(attributeName) ?: return null
+    return value.stringValues().firstOrNull { it.isNotBlank() }
+}
+
+private fun PsiAnnotationMemberValue.stringValues(): List<String> {
+    return when (this) {
+        is PsiLiteralExpression -> listOfNotNull(value as? String)
+        is PsiArrayInitializerMemberValue -> initializers.flatMap { it.stringValues() }
+        else -> emptyList()
+    }
+}
+
+private fun KtAnnotationEntry.findClassArgumentTarget(argumentName: String): PsiElement? {
+    val expression = findArgumentExpression(argumentName) as? KtClassLiteralExpression ?: return null
+    val receiver = expression.receiverExpression ?: return null
+    return receiver.lastReferenceExpression()?.reference?.resolve()
+}
+
+private fun KtAnnotationEntry.findStringArgument(argumentName: String): String? {
+    val expression = findArgumentExpression(argumentName) ?: return null
+    return expression.toUElementOfType<UExpression>()?.evaluate()?.toString()?.takeIf { it.isNotBlank() }
+}
+
+private fun KtAnnotationEntry.findArgumentExpression(argumentName: String): KtExpression? {
+    val namedArgument = valueArguments.firstOrNull { argument ->
+        argument.getArgumentName()?.asName?.identifier == argumentName
+    }
+    if (namedArgument != null) {
+        return namedArgument.getArgumentExpression()
+    }
+
+    if (argumentName != "value") {
+        return null
+    }
+
+    return valueArguments.firstOrNull { argument ->
+        argument.getArgumentName() == null
+    }?.getArgumentExpression()
+}
+
+private fun KtExpression.lastReferenceExpression(): KtReferenceExpression? {
+    return when (this) {
+        is KtReferenceExpression -> this
+        is KtDotQualifiedExpression -> selectorExpression as? KtReferenceExpression
+        else -> null
+    }
+}
+
+private fun Project.findSpringBeanTargets(beanName: String): List<PsiElement> {
+    val scope = GlobalSearchScope.projectScope(this)
+    val cache = PsiShortNamesCache.getInstance(this)
+    val targets = mutableListOf<PsiElement>()
+
+    targets.addAll(cache.getMethodsByName(beanName, scope).filter { method ->
+        method.isSpringBean(beanName)
+    })
+    targets.addAll(cache.getClassesByName(beanName.toClassNameCandidate(), scope).filter { psiClass ->
+        psiClass.isSpringBean(beanName)
+    })
+
+    if (targets.isNotEmpty()) {
+        return targets.distinct()
+    }
+
+    cache.allMethodNames.asSequence()
+        .flatMap { name -> cache.getMethodsByName(name, scope).asSequence() }
+        .filter { method -> method.isSpringBean(beanName) }
+        .forEach { method -> targets.add(method) }
+
+    cache.allClassNames.asSequence()
+        .flatMap { name -> cache.getClassesByName(name, scope).asSequence() }
+        .filter { psiClass -> psiClass.isSpringBean(beanName) }
+        .forEach { psiClass -> targets.add(psiClass) }
+
+    return targets.distinct()
+}
+
+private fun PsiClass.isSpringBean(beanName: String): Boolean {
+    val annotation = modifierList?.annotations?.find { annotation ->
+        annotation.qualifiedName in springComponentAnnotations
+    } ?: return false
+
+    val explicitNames = annotation.stringValues("value")
+    if (explicitNames.isNotEmpty()) {
+        return beanName in explicitNames
+    }
+
+    return name?.toSpringBeanName() == beanName
+}
+
+private fun PsiMethod.isSpringBean(beanName: String): Boolean {
+    val annotation = modifierList.annotations.find { annotation ->
+        annotation.qualifiedName in springBeanAnnotations
+    } ?: return false
+
+    val explicitNames = annotation.stringValues("name") + annotation.stringValues("value")
+    if (explicitNames.isNotEmpty()) {
+        return beanName in explicitNames
+    }
+
+    return name == beanName
+}
+
+private fun PsiAnnotation.stringValues(attributeName: String): List<String> {
+    val value = findDeclaredAttributeValue(attributeName) ?: return emptyList()
+    return value.stringValues()
+}
+
+private fun String.toClassNameCandidate(): String {
+    return replaceFirstChar { char ->
+        if (char.isLowerCase()) {
+            char.titlecase()
+        } else {
+            char.toString()
+        }
+    }
+}
+
+private fun String.toSpringBeanName(): String {
+    if (length > 1 && this[0].isUpperCase() && this[1].isUpperCase()) {
+        return this
+    }
+
+    return replaceFirstChar { char -> char.lowercase() }
+}
+
+private val springComponentAnnotations = setOf(
+    "org.springframework.stereotype.Component",
+    "org.springframework.stereotype.Service",
+    "org.springframework.stereotype.Repository",
+    "org.springframework.stereotype.Controller",
+    "org.springframework.web.bind.annotation.RestController",
+    "org.springframework.context.annotation.Configuration",
+    "jakarta.inject.Named",
+    "javax.inject.Named",
+)
+
+private val springBeanAnnotations = setOf(
+    "org.springframework.context.annotation.Bean",
+)
 
 fun KtProperty.isComputed(): Boolean {
     return hasTransientAnnotation() || hasFormulaAnnotation()

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
@@ -375,7 +375,7 @@ private fun KtExpression.lastReferenceExpression(): KtReferenceExpression? {
     }
 }
 
-private fun Project.findSpringBeanTargets(beanName: String): List<PsiElement> {
+fun Project.findSpringBeanTargets(beanName: String): List<PsiElement> {
     val scope = GlobalSearchScope.projectScope(this)
     val cache = PsiShortNamesCache.getInstance(this)
     val targets = mutableListOf<PsiElement>()


### PR DESCRIPTION
## Summary

Add gutter navigation for `@Transient` properties/methods in Jimmer immutable interfaces.

## Changes

- If `@Transient(value = ...)` or `@Transient(ref = ...)` is present, navigate to the resolver class or Spring bean target.
- Otherwise, fall back to the matching generated implementation member.
- Add generated source lookup helpers for Java and Kotlin immutable classes.
- Add generated method/property targets to the existing immutable property line marker.

## Scope

This PR only covers `@Transient` navigation behavior. Search filtering and tool window filtering stay in separate PRs.

## Testing

- `bash ./gradlew :core:compileKotlin --no-daemon`