### PR TITLE
Avoid UAST for Kotlin annotation icon checks

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/psi.kt
@@ -124,9 +124,7 @@ fun PsiClass.hasTypedTupleAnnotation(): Boolean {
 }
 
 fun KtClass.hasAnnotation(vararg annotations: KClass<*>): Boolean {
-    return this.toUElementOfType<UClass>()?.uAnnotations?.any { uAnnotation ->
-        annotations.map { it.qualifiedName }.any { it == uAnnotation.qualifiedName }
-    } == true
+    return annotations.any { anno -> anno.qualifiedName in annotations().map { it.fqName } }
 }
 
 fun KtClass.hasEntityAnnotation(): Boolean {


### PR DESCRIPTION
Fixes a runtime `NoClassDefFoundError: org/jetbrains/kotlin/cli/common/UtilsKt` triggered while computing Jimmer icons for Kotlin files/classes.

`KtClass.hasAnnotation()` previously converted Kotlin classes to UAST (`toUElementOfType<UClass>()`). In newer IntelliJ/Kotlin IDE builds this can force LightClass/session creation and compiler plugin extension loading. When the bundled Kotlin Lombok plugin is present, that path may fail due to the missing `org.jetbrains.kotlin.cli.common.UtilsKt` class.

This changes the Kotlin annotation check to delegate to the existing `KtClass.annotations()` PSI service and compare resolved annotation FQNs. That avoids the UAST/LightClass path while still using the project-provided annotation resolution API instead of parsing annotation entries directly.

Validation:
- `bash ./gradlew :core:compileKotlin --stacktrace`
