### PR TITLE
Preview DTO references from source

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoLineMarkerProvider.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoLineMarkerProvider.kt
@@ -18,15 +18,17 @@ package cn.enaium.jimmer.buddy.extensions.dto.insight
 
 import cn.enaium.jimmer.buddy.JimmerBuddy
 import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiDtoType
-import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiRoot
+import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiName
 import cn.enaium.jimmer.buddy.utility.DTO_TYPE
+import cn.enaium.jimmer.buddy.utility.generatedReferences
+import cn.enaium.jimmer.buddy.utility.runReadOnly
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
-import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.findParentOfType
-import org.jetbrains.kotlin.idea.base.util.allScope
+import com.intellij.psi.util.PsiTreeUtil
+import java.awt.event.MouseEvent
 
 /**
  * @author Enaium
@@ -36,22 +38,56 @@ class DtoLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
     ) {
-        if (element is DtoPsiDtoType) {
-            val name = element.name?.value ?: return
-            val dtoPsiRoot = element.findParentOfType<DtoPsiRoot>() ?: return
-            val exportType = dtoPsiRoot.qualifiedName() ?: return
-            val exportPackage =
-                dtoPsiRoot.exportStatement?.packageParts?.qualifiedName()
-                    ?: "${exportType.substringBeforeLast(".")}.dto"
+        val dtoType = element.dtoType() ?: return
+        val name = dtoType.name ?: return
+        val anchor = name.firstChild ?: name
+        if (element != anchor) {
+            return
+        }
 
-            val target =
-                JavaPsiFacade.getInstance(element.project).findClass("$exportPackage.$name", element.project.allScope())
-                    ?: return
+        result.add(
+            NavigationGutterIconBuilder.create(JimmerBuddy.Icons.Nodes.DTO_TYPE)
+                .setTarget(name)
+                .setTooltipText("Choose DTO Reference")
+                .createLineMarkerInfo(anchor, DtoReferenceNavigationHandler(dtoType))
+        )
+    }
 
-            result.add(
-                NavigationGutterIconBuilder.create(JimmerBuddy.Icons.Nodes.DTO_TYPE).setTargets(listOf(target))
-                    .createLineMarkerInfo(element)
-            )
+    private class DtoReferenceNavigationHandler(
+        private val dtoType: DtoPsiDtoType,
+    ) : GutterIconNavigationHandler<PsiElement> {
+        override fun navigate(
+            event: MouseEvent,
+            elt: PsiElement,
+        ) {
+            val references = runReadOnly {
+                if (dtoType.isValid) {
+                    dtoType.generatedReferences()
+                } else {
+                    emptyList()
+                }
+            }
+            DtoReferencePreview.show(references, event)
+        }
+    }
+
+    private companion object {
+        private fun PsiElement.dtoType(): DtoPsiDtoType? {
+            if (this is DtoPsiDtoType) {
+                return this
+            }
+
+            val name = when (this) {
+                is DtoPsiName -> this
+                else -> PsiTreeUtil.getParentOfType(this, DtoPsiName::class.java, false)
+            } ?: return null
+
+            val dtoType = name.parent as? DtoPsiDtoType ?: return null
+            if (dtoType.name != name) {
+                return null
+            }
+
+            return dtoType
         }
     }
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferenceEditorFactoryListener.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferenceEditorFactoryListener.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Enaium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.enaium.jimmer.buddy.extensions.dto.insight
+
+import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiDtoType
+import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiFile
+import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiName
+import cn.enaium.jimmer.buddy.utility.generatedReferences
+import cn.enaium.jimmer.buddy.utility.runReadOnly
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseEventArea
+import com.intellij.openapi.editor.event.EditorMouseListener
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import java.util.concurrent.ConcurrentHashMap
+import javax.swing.SwingUtilities
+
+class DtoReferenceEditorFactoryListener : EditorFactoryListener {
+    private val listeners = ConcurrentHashMap<Editor, EditorMouseListener>()
+
+    override fun editorCreated(event: EditorFactoryEvent) {
+        val editor = event.editor
+        val listener = DtoReferenceMouseListener()
+        listeners[editor] = listener
+        editor.addEditorMouseListener(listener)
+    }
+
+    override fun editorReleased(event: EditorFactoryEvent) {
+        val editor = event.editor
+        val listener = listeners.remove(editor) ?: return
+        editor.removeEditorMouseListener(listener)
+    }
+
+    private class DtoReferenceMouseListener : EditorMouseListener {
+        override fun mousePressed(event: EditorMouseEvent) {
+            if (!event.shouldHandleDtoReferenceClick()) {
+                return
+            }
+
+            val references = event.findDtoReferencesAtMouseOffset()
+            if (references.isEmpty()) {
+                return
+            }
+
+            if (DtoReferencePreview.show(references, event.mouseEvent)) {
+                event.consume()
+                event.mouseEvent.consume()
+            }
+        }
+
+        private fun EditorMouseEvent.shouldHandleDtoReferenceClick(): Boolean {
+            val mouseEvent = mouseEvent
+            if (!SwingUtilities.isLeftMouseButton(mouseEvent)) {
+                return false
+            }
+
+            if (mouseEvent.clickCount != 1) {
+                return false
+            }
+
+            if (area != EditorMouseEventArea.EDITING_AREA || !isOverText) {
+                return false
+            }
+
+            val clickEditor = editor
+            if (clickEditor.isViewer || clickEditor.selectionModel.hasSelection()) {
+                return false
+            }
+
+            return true
+        }
+
+        private fun EditorMouseEvent.findDtoReferencesAtMouseOffset(): List<PsiElement> {
+            val project = editor.project ?: return emptyList()
+            val documentManager = PsiDocumentManager.getInstance(project)
+            documentManager.commitDocument(editor.document)
+
+            return runReadOnly {
+                val file = documentManager.getPsiFile(editor.document) as? DtoPsiFile ?: return@runReadOnly emptyList()
+                val dtoType = findDtoTypeAtOffset(file, offset) ?: return@runReadOnly emptyList()
+                dtoType.generatedReferences()
+            }
+        }
+
+        private fun findDtoTypeAtOffset(
+            file: DtoPsiFile,
+            offset: Int,
+        ): DtoPsiDtoType? {
+            val safeOffset = offset.coerceIn(0, file.textLength)
+            val previousOffset = (safeOffset - 1).coerceAtLeast(0)
+            val name = listOf(safeOffset, previousOffset)
+                .asSequence()
+                .mapNotNull { file.findElementAt(it) }
+                .mapNotNull { PsiTreeUtil.getParentOfType(it, DtoPsiName::class.java, false) }
+                .firstOrNull { it.textRange.containsOffset(safeOffset) || it.textRange.containsOffset(previousOffset) }
+                ?: return null
+            val dtoType = name.parent as? DtoPsiDtoType ?: return null
+            if (dtoType.name != name) {
+                return null
+            }
+
+            return dtoType
+        }
+    }
+}

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferencePreview.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferencePreview.kt
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025 Enaium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.enaium.jimmer.buddy.extensions.dto.insight
+
+import cn.enaium.jimmer.buddy.utility.runReadOnly
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.JSplitPane
+import javax.swing.ListSelectionModel
+
+internal object DtoReferencePreview {
+    fun show(
+        references: List<PsiElement>,
+        event: MouseEvent,
+    ): Boolean {
+        val validReferences = references.filter { it.isValid }
+        if (validReferences.isEmpty()) {
+            JBPopupFactory.getInstance()
+                .createMessage("No DTO references found")
+                .show(RelativePoint(event))
+            return true
+        }
+
+        DtoReferencePreviewPopup(validReferences).show(event)
+        return true
+    }
+}
+
+private class DtoReferencePreviewPopup(
+    private val references: List<PsiElement>,
+) {
+    private val project = references.first().project
+    private val referenceList = JBList(references)
+    private val previewPanel = JPanel(BorderLayout())
+    private var editor: Editor? = null
+    private var popup: JBPopup? = null
+
+    fun show(event: MouseEvent) {
+        referenceList.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        referenceList.cellRenderer = DtoReferenceListRenderer()
+        referenceList.selectedIndex = 0
+        referenceList.addListSelectionListener { event ->
+            if (!event.valueIsAdjusting) {
+                updatePreview(referenceList.selectedValue)
+            }
+        }
+        referenceList.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(event: MouseEvent) {
+                if (event.clickCount == 2) {
+                    navigateSelectedReference()
+                }
+            }
+        })
+        referenceList.addKeyListener(object : KeyAdapter() {
+            override fun keyPressed(event: KeyEvent) {
+                if (event.keyCode == KeyEvent.VK_ENTER) {
+                    navigateSelectedReference()
+                }
+            }
+        })
+
+        updatePreview(referenceList.selectedValue)
+
+        val content = createContent()
+        val createdPopup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(content, referenceList)
+            .setTitle("Choose DTO Reference")
+            .setResizable(true)
+            .setMovable(true)
+            .setRequestFocus(true)
+            .setProject(project)
+            .createPopup()
+
+        popup = createdPopup
+        Disposer.register(createdPopup, Disposable { releaseEditor() })
+        createdPopup.show(RelativePoint(event))
+    }
+
+    private fun createContent(): JComponent {
+        val listPanel = JBScrollPane(referenceList)
+        listPanel.preferredSize = Dimension(360, 560)
+        previewPanel.preferredSize = Dimension(760, 560)
+
+        val splitPane = JSplitPane(JSplitPane.HORIZONTAL_SPLIT, listPanel, previewPanel)
+        splitPane.preferredSize = Dimension(1120, 560)
+        splitPane.dividerLocation = 360
+        splitPane.resizeWeight = 0.0
+        return splitPane
+    }
+
+    private fun updatePreview(reference: PsiElement?) {
+        previewPanel.removeAll()
+        releaseEditor()
+
+        if (reference == null || !reference.isValid) {
+            previewPanel.add(JLabel("No preview available"), BorderLayout.CENTER)
+            refreshPreviewPanel()
+            return
+        }
+
+        val preview = createPreview(reference)
+        if (preview == null) {
+            previewPanel.add(JLabel("No preview available"), BorderLayout.CENTER)
+            refreshPreviewPanel()
+            return
+        }
+
+        val createdEditor = createPreviewEditor(preview)
+        editor = createdEditor
+        previewPanel.add(createdEditor.component, BorderLayout.CENTER)
+        createdEditor.caretModel.moveToOffset(preview.offset)
+        createdEditor.selectionModel.setSelection(preview.offset, preview.endOffset)
+        createdEditor.scrollingModel.scrollToCaret(ScrollType.CENTER)
+        refreshPreviewPanel()
+    }
+
+    private fun createPreview(reference: PsiElement): DtoReferencePreviewInfo? {
+        return runReadOnly {
+            if (!reference.isValid) {
+                return@runReadOnly null
+            }
+
+            val file = reference.containingFile ?: return@runReadOnly null
+            val document = PsiDocumentManager.getInstance(project).getDocument(file)
+                ?: EditorFactory.getInstance().createDocument(file.text)
+            val offset = reference.textRange.startOffset.coerceIn(0, document.textLength)
+            val endOffset = reference.textRange.endOffset.coerceIn(offset, document.textLength)
+
+            DtoReferencePreviewInfo(
+                document = document,
+                virtualFile = file.virtualFile,
+                offset = offset,
+                endOffset = endOffset,
+            )
+        }
+    }
+
+    private fun createPreviewEditor(preview: DtoReferencePreviewInfo): Editor {
+        val factory = EditorFactory.getInstance()
+        val virtualFile = preview.virtualFile
+        if (virtualFile != null) {
+            return factory.createEditor(preview.document, project, virtualFile, true)
+        }
+
+        return factory.createViewer(preview.document, project)
+    }
+
+    private fun navigateSelectedReference() {
+        val reference = referenceList.selectedValue ?: return
+        val location = reference.navigationLocation() ?: return
+        popup?.cancel()
+        OpenFileDescriptor(project, location.virtualFile, location.offset).navigate(true)
+    }
+
+    private fun PsiElement.navigationLocation(): DtoReferenceNavigationLocation? {
+        return runReadOnly {
+            if (!isValid) {
+                return@runReadOnly null
+            }
+
+            val file = containingFile?.virtualFile ?: return@runReadOnly null
+            val offset = textRange.startOffset
+            DtoReferenceNavigationLocation(file, offset)
+        }
+    }
+
+    private fun refreshPreviewPanel() {
+        previewPanel.revalidate()
+        previewPanel.repaint()
+    }
+
+    private fun releaseEditor() {
+        val oldEditor = editor ?: return
+        editor = null
+        if (!oldEditor.isDisposed) {
+            EditorFactory.getInstance().releaseEditor(oldEditor)
+        }
+    }
+}
+
+private class DtoReferenceListRenderer : DefaultListCellRenderer() {
+    override fun getListCellRendererComponent(
+        list: JList<*>,
+        value: Any?,
+        index: Int,
+        isSelected: Boolean,
+        cellHasFocus: Boolean,
+    ): Component {
+        val component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+        val label = component as JLabel
+        val element = value as? PsiElement ?: return label
+        val presentation = runReadOnly {
+            element.referencePresentation()
+        }
+
+        label.text = "${presentation.locationText}  ${presentation.lineText}"
+        label.toolTipText = presentation.lineText
+        label.icon = element.getIcon(0)
+        return label
+    }
+}
+
+private data class DtoReferencePreviewInfo(
+    val document: Document,
+    val virtualFile: VirtualFile?,
+    val offset: Int,
+    val endOffset: Int,
+)
+
+private data class DtoReferenceNavigationLocation(
+    val virtualFile: VirtualFile,
+    val offset: Int,
+)
+
+private data class DtoReferencePresentation(
+    val lineText: String,
+    val locationText: String,
+)
+
+private fun PsiElement.referencePresentation(): DtoReferencePresentation {
+    val file = containingFile ?: return DtoReferencePresentation(text, "")
+    val fileName = file.virtualFile?.name ?: file.name
+    val document = PsiDocumentManager.getInstance(project).getDocument(file)
+
+    if (document == null) {
+        return DtoReferencePresentation(text.normalizeCodeLine(), fileName)
+    }
+
+    val line = document.getLineNumber(textRange.startOffset)
+    val lineStart = document.getLineStartOffset(line)
+    val lineEnd = document.getLineEndOffset(line)
+    val lineText = document.text.substring(lineStart, lineEnd).normalizeCodeLine()
+
+    return DtoReferencePresentation(
+        lineText.ifEmpty { text.normalizeCodeLine() },
+        "$fileName:${line + 1}",
+    )
+}
+
+private fun String.normalizeCodeLine(): String {
+    return trim().replace(Regex("\\s+"), " ")
+}

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferencesCodeVisionProvider.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/insight/DtoReferencesCodeVisionProvider.kt
@@ -16,21 +16,22 @@
 
 package cn.enaium.jimmer.buddy.extensions.dto.insight
 
+import cn.enaium.jimmer.buddy.JimmerBuddy
 import cn.enaium.jimmer.buddy.extensions.dto.DtoLanguage
 import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiDtoType
-import cn.enaium.jimmer.buddy.utility.generatedName
+import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiName
+import cn.enaium.jimmer.buddy.utility.generatedReferences
+import com.intellij.codeInsight.codeVision.CodeVisionEntry
 import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
+import com.intellij.codeInsight.codeVision.ui.model.ClickableTextCodeVisionEntry
 import com.intellij.codeInsight.hints.codeVision.CodeVisionProviderBase
-import com.intellij.codeInsight.navigation.actions.GotoDeclarationAction
 import com.intellij.java.JavaBundle
 import com.intellij.openapi.editor.Editor
-import com.intellij.psi.JavaPsiFacade
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.search.searches.ReferencesSearch
-import com.intellij.ui.awt.RelativePoint
-import org.jetbrains.kotlin.idea.base.util.allScope
-import org.jetbrains.kotlin.idea.base.util.projectScope
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.util.PsiTreeUtil
 import java.awt.event.MouseEvent
 
 /**
@@ -45,24 +46,52 @@ class DtoReferencesCodeVisionProvider : CodeVisionProviderBase() {
         get() = "JimmerBuddy.dto.usages"
 
     override fun acceptsElement(element: PsiElement): Boolean {
-        return element is DtoPsiDtoType
+        return element is DtoPsiName && element.parent is DtoPsiDtoType
     }
 
     override fun acceptsFile(file: PsiFile): Boolean {
         return file.language == DtoLanguage
     }
 
-    override fun getHint(element: PsiElement, file: PsiFile): String? {
-        if (element is DtoPsiDtoType) {
-            val target =
-                JavaPsiFacade.getInstance(element.project)
-                    .findClass(element.generatedName() ?: return null, element.project.allScope())
-                    ?: return null
-
-            val search = ReferencesSearch.search(target, element.project.projectScope())
-            return JavaBundle.message("usages.telescope", search.count())
+    override fun computeForEditor(
+        editor: Editor,
+        file: PsiFile
+    ): List<Pair<TextRange, CodeVisionEntry>> {
+        if (!acceptsFile(file)) {
+            return emptyList()
         }
-        return null
+
+        return PsiTreeUtil.collectElementsOfType(file, DtoPsiDtoType::class.java)
+            .mapNotNull { dtoType ->
+                val name = dtoType.name ?: return@mapNotNull null
+                val hint = getHint(dtoType, file) ?: return@mapNotNull null
+                val pointer = SmartPointerManager.createPointer(dtoType)
+                val clickHandler = { event: MouseEvent?, clickEditor: Editor ->
+                    val element = pointer.element
+                    if (element != null) {
+                        handleClick(clickEditor, element, event)
+                    }
+                }
+                val entry = ClickableTextCodeVisionEntry(
+                    hint,
+                    id,
+                    clickHandler,
+                    null,
+                    "",
+                    "",
+                    emptyList()
+                )
+                name.textRange to entry
+            }
+    }
+
+    override fun getHint(element: PsiElement, file: PsiFile): String? {
+        val dtoType = element.dtoType() ?: return null
+        val count = dtoType.generatedReferences().size
+        if (count == 0) {
+            return null
+        }
+        return JavaBundle.message("usages.telescope", count)
     }
 
     override fun handleClick(
@@ -70,18 +99,21 @@ class DtoReferencesCodeVisionProvider : CodeVisionProviderBase() {
         element: PsiElement,
         event: MouseEvent?
     ) {
-        if (element is DtoPsiDtoType) {
-            val target =
-                JavaPsiFacade.getInstance(element.project)
-                    .findClass(element.generatedName() ?: return, element.project.allScope())
-                    ?: return
+        val dtoType = element.dtoType() ?: return
+        val references = dtoType.generatedReferences()
+        if (references.isEmpty()) {
+            return
+        }
 
-            GotoDeclarationAction.startFindUsages(
-                editor,
-                target.project,
-                target,
-                if (event == null) null else RelativePoint(event)
-            )
+        JimmerBuddy.Services.NAVIGATION.getPsiElementPopup(references, "Choose DTO Reference")
+            .showInBestPositionFor(editor)
+    }
+
+    private fun PsiElement.dtoType(): DtoPsiDtoType? {
+        return when (this) {
+            is DtoPsiDtoType -> this
+            is DtoPsiName -> parent as? DtoPsiDtoType
+            else -> null
         }
     }
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/psi/impl/DtoPsiDtoTypeImpl.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/psi/impl/DtoPsiDtoTypeImpl.kt
@@ -21,11 +21,8 @@ import cn.enaium.jimmer.buddy.extensions.dto.DtoLanguage.findChild
 import cn.enaium.jimmer.buddy.extensions.dto.DtoLanguage.findChildren
 import cn.enaium.jimmer.buddy.extensions.dto.psi.*
 import cn.enaium.jimmer.buddy.utility.DTO_TYPE
-import cn.enaium.jimmer.buddy.utility.generatedName
 import com.intellij.lang.ASTNode
-import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.idea.base.util.allScope
 import javax.swing.Icon
 
 class DtoPsiDtoTypeImpl(node: ASTNode) : DtoPsiNamedElement(node), DtoPsiDtoType {
@@ -42,10 +39,19 @@ class DtoPsiDtoTypeImpl(node: ASTNode) : DtoPsiNamedElement(node), DtoPsiDtoType
         return JimmerBuddy.Icons.Nodes.DTO_TYPE
     }
 
+    override fun getNameIdentifier(): PsiElement {
+        return name ?: this
+    }
+
+    override fun getNavigationElement(): PsiElement {
+        return name ?: this
+    }
+
+    override fun getTextOffset(): Int {
+        return name?.textOffset ?: super.getTextOffset()
+    }
+
     override fun reference(): PsiElement? {
-        val target =
-            JavaPsiFacade.getInstance(project).findClass(generatedName() ?: return null, project.allScope())
-                ?: return null
-        return target
+        return name ?: this
     }
 }

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/psi/impl/DtoPsiNameImpl.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/psi/impl/DtoPsiNameImpl.kt
@@ -48,12 +48,7 @@ class DtoPsiNameImpl(node: ASTNode) : DtoPsiNamedElement(node), DtoPsiName {
             }
 
             is DtoPsiDtoType -> {
-                val dtoPsiRoot = parentElement.findParentOfType<DtoPsiRoot>() ?: return null
-                val exportType = dtoPsiRoot.qualifiedName() ?: return null
-                val exportPackage = dtoPsiRoot.exportStatement?.packageParts?.qualifiedName()
-                    ?: "${exportType.substringBeforeLast(".")}.dto"
-                JavaPsiFacade.getInstance(parentElement.project)
-                    .findClass("$exportPackage.$name", parentElement.project.allScope())
+                parentElement
             }
 
             is DtoPsiEnumMapping -> {

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/dto.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/dto.kt
@@ -23,8 +23,23 @@ import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiFile
 import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiProp
 import cn.enaium.jimmer.buddy.extensions.dto.psi.DtoPsiRoot
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.PsiSearchHelper
+import com.intellij.psi.search.SearchScope
+import com.intellij.psi.search.UsageSearchContext
+import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.findParentOfType
+import org.babyfish.jimmer.internal.GeneratedBy
+import org.jetbrains.kotlin.idea.base.util.allScope
+import org.jetbrains.kotlin.idea.base.util.projectScope
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.toUElementOfType
 
 /**
  * @author Enaium
@@ -47,3 +62,170 @@ fun DtoPsiDtoType.generatedName(): String? {
 
     return "$exportPackage.$name"
 }
+
+fun DtoPsiDtoType.generatedReferences(): List<PsiElement> {
+    val references = generatedReferenceSearchResults(project.projectScope())
+        .map { it.element }
+    if (references.isNotEmpty()) {
+        return references
+    }
+
+    return generatedSourceReferenceElements(project.projectScope())
+}
+
+fun DtoPsiDtoType.generatedReferenceSearchResults(scope: SearchScope): List<PsiReference> {
+    val target = JavaPsiFacade.getInstance(project)
+        .findClass(generatedName() ?: return emptyList(), project.allScope())
+        ?: return emptyList()
+    val targetFiles = listOfNotNull(
+        target.containingFile?.virtualFile,
+        target.navigationElement.containingFile?.virtualFile,
+        target.originalElement.containingFile?.virtualFile,
+    ).toSet()
+
+    return ReferencesSearch.search(target, scope)
+        .mapNotNull { reference ->
+            val virtualFile = reference.element.containingFile?.virtualFile ?: return@mapNotNull null
+            reference.takeIf {
+                virtualFile !in targetFiles &&
+                    !virtualFile.path.isGeneratedPath() &&
+                    !isJimmerGeneratedDtoFile(reference.element)
+            }
+        }
+        .toList()
+}
+
+private fun DtoPsiDtoType.generatedSourceReferenceElements(scope: SearchScope): List<PsiElement> {
+    val generatedName = generatedName() ?: return emptyList()
+    val simpleName = generatedName.substringAfterLast(".")
+    val references = linkedMapOf<String, PsiElement>()
+
+    PsiSearchHelper.getInstance(project).processElementsWithWord(
+        { element, offset ->
+            val reference = element.findGeneratedSourceReference(simpleName, generatedName, offset)
+            if (reference != null) {
+                val file = reference.containingFile?.virtualFile
+                if (file != null) {
+                    references["${file.path}:${reference.textRange.startOffset}"] = reference
+                }
+            }
+            true
+        },
+        scope,
+        simpleName,
+        UsageSearchContext.IN_CODE,
+        true,
+    )
+
+    return references.values.toList()
+}
+
+private fun PsiElement.findGeneratedSourceReference(
+    simpleName: String,
+    generatedName: String,
+    offset: Int,
+): PsiElement? {
+    val reference = findLeafAtRelativeOffset(offset)?.takeIf { it.text == simpleName }
+        ?: findLeafWithText(simpleName)
+        ?: return null
+    if (!reference.isGeneratedSourceReference(generatedName)) {
+        return null
+    }
+
+    return reference
+}
+
+private fun PsiElement.findLeafAtRelativeOffset(offset: Int): PsiElement? {
+    val file = containingFile ?: return null
+    val absoluteOffset = textRange.startOffset + offset
+    return file.findElementAt(absoluteOffset)
+}
+
+private fun PsiElement.findLeafWithText(text: String): PsiElement? {
+    if (firstChild == null) {
+        return takeIf { it.text == text }
+    }
+
+    var child = firstChild
+    while (child != null) {
+        val found = child.findLeafWithText(text)
+        if (found != null) {
+            return found
+        }
+        child = child.nextSibling
+    }
+
+    return null
+}
+
+private fun PsiElement.isGeneratedSourceReference(generatedName: String): Boolean {
+    val file = containingFile ?: return false
+    if (file is DtoPsiFile) {
+        return false
+    }
+
+    val virtualFile = file.virtualFile ?: return false
+    if (!virtualFile.isUserSourceFile()) {
+        return false
+    }
+
+    val text = file.text
+    if (text.contains(generatedName)) {
+        return true
+    }
+
+    val importText = "import $generatedName"
+    if (text.contains(importText)) {
+        return true
+    }
+
+    val generatedPackage = generatedName.substringBeforeLast(".")
+    return file.packageName() == generatedPackage
+}
+
+private fun VirtualFile.isUserSourceFile(): Boolean {
+    if (path.isGeneratedPath()) {
+        return false
+    }
+
+    val extension = extension ?: return false
+    return extension == "java" || extension == "kt"
+}
+
+private fun PsiElement.packageName(): String? {
+    return when (this) {
+        is PsiJavaFile -> packageName
+        is KtFile -> packageFqName.asString()
+        else -> null
+    }
+}
+
+private fun String.isGeneratedPath(): Boolean {
+    return split('/', '\\').any { it in generatedDirectoryNames }
+}
+
+private fun isJimmerGeneratedDtoFile(element: PsiElement): Boolean {
+    val file = element.containingFile ?: return false
+    val generatedByDto = file.toUElementOfType<UFile>()?.classes?.any { uClass ->
+        uClass.uAnnotations.any { annotation ->
+            if (annotation.qualifiedName != GeneratedBy::class.qualifiedName) {
+                return@any false
+            }
+
+            annotation.findAttributeValue("file")?.evaluate()?.toString()?.endsWith(".dto") == true
+        }
+    } == true
+
+    if (generatedByDto) {
+        return true
+    }
+
+    val text = file.text
+    return text.contains("GeneratedBy") && text.contains(".dto")
+}
+
+private val generatedDirectoryNames = setOf(
+    "generated",
+    "generated-sources",
+    ".apt_generated",
+)

--- a/since/shared/resources/META-INF/plugin.xml
+++ b/since/shared/resources/META-INF/plugin.xml
@@ -200,6 +200,7 @@
         <fileBasedIndex implementation="cn.enaium.jimmer.buddy.extensions.index.FullClassIndex"/>
         <codeInsight.lineMarkerProvider language="JimmerBuddy.DTO" id="JimmerBuddy.JavaLineMark"
                                         implementationClass="cn.enaium.jimmer.buddy.extensions.dto.insight.DtoLineMarkerProvider"/>
+        <editorFactoryListener implementation="cn.enaium.jimmer.buddy.extensions.dto.insight.DtoReferenceEditorFactoryListener"/>
         <lang.formatter language="JimmerBuddy.DTO"
                         implementationClass="cn.enaium.jimmer.buddy.extensions.dto.formatter.DtoFormattingModelBuilder"/>
         <lang.braceMatcher language="JimmerBuddy.DTO"
@@ -301,5 +302,4 @@
         </group>
     </actions>
 </idea-plugin>
-
 


### PR DESCRIPTION
## Summary
- navigate DTO declarations to source usages instead of generated DTO classes
- show a preview popup with selectable reference list and code preview
- allow clicking the DTO type name to open the same preview as the gutter icon

## Scope check
- rebased on latest `origin/master` (`b30ed5a`)
- single feature commit only: `3f62c26`
- diff is limited to DTO reference navigation/preview files

## Test
- `bash gradlew --no-configuration-cache :core:compileKotlin`
- `bash gradlew --no-configuration-cache buildPlugins`