### PR TITLE
fix: correct common columns generation condition

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/database/generate/JavaEntityGenerate.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/database/generate/JavaEntityGenerate.kt
@@ -51,7 +51,7 @@ class JavaEntityGenerate : EntityGenerate {
 
         val idSuffix = "_${generateEntity.primaryKeyName}"
 
-        val commonColumns = if (generateEntity.baseEntity || tables.size == 1) getCommonColumns(tables) else emptyList()
+        val commonColumns = if (generateEntity.baseEntity || tables.size > 1) getCommonColumns(tables) else emptyList()
 
         val type2Builder = mutableMapOf<String, TypeSpec.Builder>()
 

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/database/generate/KotlinEntityGenerate.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/database/generate/KotlinEntityGenerate.kt
@@ -50,7 +50,7 @@ class KotlinEntityGenerate : EntityGenerate {
 
         val idSuffix = "_${generateEntity.primaryKeyName}"
 
-        val commonColumns = if (generateEntity.baseEntity || tables.size == 1) getCommonColumns(tables) else emptyList()
+        val commonColumns = if (generateEntity.baseEntity || tables.size > 1) getCommonColumns(tables) else emptyList()
 
         val type2Builder = mutableMapOf<String, TypeSpec.Builder>()
 


### PR DESCRIPTION
  Changes

  - JavaEntityGenerate.kt — change tables.size == 1 to tables.size > 1 in the commonColumns guard.
  - KotlinEntityGenerate.kt — same fix for the Kotlin generator.

  Impact

  - Generating an entity from a single table now produces a normal entity with all of its columns and no spurious BaseEntity.
  - Generating from multiple tables is unchanged in the common case, and shared columns are now extracted even when the baseEntity option is off — matching the option's intent as an explicit override rather than the only path.
  ---
  One thing worth your judgment before merging: with baseEntity off and multiple tables, extraction now runs where it previously did not. If baseEntity was meant to be a strict opt-in gate, the condition should be generateEntity.baseEntity && tables.size > 1 instead. 