### PR TITLE
fix(debugger): avoid internal applicability API

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/debugger/JimmerImmutableRenderer.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/debugger/JimmerImmutableRenderer.kt
@@ -79,13 +79,7 @@ class JimmerImmutableRendererProvider : CompoundRendererProvider() {
     }
 
     override fun getIsApplicableChecker(): Function<Type?, CompletableFuture<Boolean>> {
-        return Function { type ->
-            if (type == null) {
-                CompletableFuture.completedFuture(false)
-            } else {
-                renderer.isApplicableAsync(type)
-            }
-        }
+        return Function { type -> JimmerImmutableRenderer.checkApplicability(type) }
     }
 
     override fun isEnabled(): Boolean {
@@ -94,17 +88,6 @@ class JimmerImmutableRendererProvider : CompoundRendererProvider() {
 }
 
 class JimmerImmutableRenderer : NodeRendererImpl("Jimmer Immutable", true), FullValueEvaluatorProvider {
-
-    init {
-        setIsApplicableChecker { type ->
-            when {
-                type !is ReferenceType -> CompletableFuture.completedFuture(false)
-                type.hasJimmerBackingFields() -> CompletableFuture.completedFuture(true)
-                else -> DebuggerUtilsAsync.instanceOf(type, IMMUTABLE_SPI)
-            }
-        }
-    }
-
     override fun getUniqueId(): String {
         return "JimmerImmutableRenderer"
     }
@@ -218,7 +201,7 @@ class JimmerImmutableRenderer : NodeRendererImpl("Jimmer Immutable", true), Full
         }
     }
 
-    private companion object {
+    internal companion object {
         private const val IMMUTABLE_SPI = "org.babyfish.jimmer.runtime.ImmutableSpi"
         private const val FIELD_PREFIX = "__"
         private const val LOADED_SUFFIX = "Loaded"
@@ -228,6 +211,14 @@ class JimmerImmutableRenderer : NodeRendererImpl("Jimmer Immutable", true), Full
         private const val LABEL_VALUE_LIMIT = 6
         private const val JSON_DEPTH_LIMIT = 5
         private const val JSON_ARRAY_LIMIT = 50
+
+        internal fun checkApplicability(type: Type?): CompletableFuture<Boolean> {
+            return when {
+                type !is ReferenceType -> CompletableFuture.completedFuture(false)
+                type.hasJimmerBackingFields() -> CompletableFuture.completedFuture(true)
+                else -> DebuggerUtilsAsync.instanceOf(type, IMMUTABLE_SPI)
+            }
+        }
 
         private fun ReferenceType.hasJimmerBackingFields(): Boolean {
             val hasTypeMethod = methodsByName(TYPE_METHOD, TYPE_METHOD_SIGNATURE).isNotEmpty()


### PR DESCRIPTION
## Summary

- Remove the direct call to `NodeRendererImpl.setIsApplicableChecker(Function)`, which is annotated with `ApiStatus.Internal`.
- Move the existing Jimmer structural and `ImmutableSpi` applicability logic into `CompoundRendererProvider.getIsApplicableChecker()`, the debugger extension point intended for compound renderers.
- Preserve Kotlin/KSP generated-type detection and nullable JDI type handling without changing labels, children, JSON rendering, or renderer priority.

## Verification

- `sh gradlew :core:compileKotlin` succeeded.
- `:since:261:verifyPluginStructure` and `:since:261:verifyPluginProjectConfiguration` completed; the latter reports only existing project-level configuration warnings.
- IntelliJ Plugin Verifier 1.409 reports the plugin as `Compatible` with both `IU-261.26222.65` and `IU-262.8665.337`, with no `setIsApplicableChecker` or internal API finding.
- A focused JDI probe against `DebugRuleDraft$$$Impl` returned `generated-type-applicable=true`.
- The nullable-type probe returned `null-type-applicable=false`.
