### PR TITLE
fix: dto #allScalars generates @IdView properties

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/JimmerBuddy.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/JimmerBuddy.kt
@@ -654,7 +654,10 @@ object JimmerBuddy {
                                         val classDeclarationByName =
                                             resolver.getClassDeclarationByName(compiler.sourceTypeName)
                                                 ?: return@forEach
-                                        val compile = compiler.compile(option.context.typeOf(classDeclarationByName))
+                                        val immutableType =
+                                            option.context.typeOf(classDeclarationByName)
+                                        option.context.resolve()
+                                        val compile = compiler.compile(immutableType)
                                         compile.forEach { dtoType ->
                                             if (name != null && dtoType.name != name) {
                                                 return@forEach

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/inspection/DtoInspection.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/inspection/DtoInspection.kt
@@ -106,8 +106,10 @@ class DtoInspection : LocalInspectionTool() {
                         val compiler = KspDtoCompiler(dtoFile, context, DtoModifier.STATIC)
                         val classDeclarationByName =
                             resolver.getClassDeclarationByName(compiler.sourceTypeName) ?: return
+                        val immutableType = context.typeOf(classDeclarationByName)
+                        context.resolve()
                         registerProblem(file, document, holder) {
-                            compiler.compile(context.typeOf(classDeclarationByName))
+                            compiler.compile(immutableType)
                         }
                     } catch (_: Throwable) {
 


### PR DESCRIPTION
Fixes #207

## 根因

Kotlin(KSP) 路径的 DTO 生成（`dtoProcessKotlin`）调用了 `context.typeOf(...)` 但从未调用 `Context.resolve()`。jimmer-ksp 中 `ImmutableProp.getIdViewBaseProp()` 只返回 `_idViewBaseProp` 字段，该字段仅由 `resolveIdViewBaseProp()`（通过 `Context.resolve()` phase 1 触发）赋值。字段保持 null 时，`DtoTypeBuilder.isAutoScalar` 会把 `@IdView` 属性当作普通标量包含进 `#allScalars` 生成结果。

真实 KSP 构建（`ImmutableProcessor`/`DtoProcessor`）会调用 `Context.resolve()`，因此实际构建产物正确排除了 `@IdView` 属性。Java(APT) 路径不受影响，因为 jimmer-apt 的 `getIdViewBaseProp()` 是惰性解析。

## 改动

- `JimmerBuddy.kt` `dtoProcessKotlin`：在 `typeOf()` 之后、`compile()` 之前调用 `option.context.resolve()`
- `DtoInspection.kt` Kotlin 分支：同样补充 `context.resolve()`