### PR TITLE
fix: dto #allScalars generates @IdView properties

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/JimmerBuddy.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/JimmerBuddy.kt
@@ -654,7 +654,10 @@ object JimmerBuddy {
                                         val classDeclarationByName =
                                             resolver.getClassDeclarationByName(compiler.sourceTypeName)
                                                 ?: return@forEach
-                                        val compile = compiler.compile(option.context.typeOf(classDeclarationByName))
+                                        val immutableType =
+                                            option.context.typeOf(classDeclarationByName)
+                                        option.context.resolve()
+                                        val compile = compiler.compile(immutableType)
                                         compile.forEach { dtoType ->
                                             if (name != null && dtoType.name != name) {
                                                 return@forEach

--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/inspection/DtoInspection.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/extensions/dto/inspection/DtoInspection.kt
@@ -106,8 +106,10 @@ class DtoInspection : LocalInspectionTool() {
                         val compiler = KspDtoCompiler(dtoFile, context, DtoModifier.STATIC)
                         val classDeclarationByName =
                             resolver.getClassDeclarationByName(compiler.sourceTypeName) ?: return
+                        val immutableType = context.typeOf(classDeclarationByName)
+                        context.resolve()
                         registerProblem(file, document, holder) {
-                            compiler.compile(context.typeOf(classDeclarationByName))
+                            compiler.compile(immutableType)
                         }
                     } catch (_: Throwable) {
 


### PR DESCRIPTION
Fixes #207

## Root cause

The Kotlin (KSP) DTO generation path (`dtoProcessKotlin`) calls `context.typeOf(...)` but never calls `Context.resolve()`. In jimmer-ksp, `ImmutableProp.getIdViewBaseProp()` returns the `_idViewBaseProp` field, which is only populated by `resolveIdViewBaseProp()` — invoked exclusively through `Context.resolve()` (phase 1). Since the field stays `null`, `DtoTypeBuilder.isAutoScalar` treats `@IdView` properties as plain scalars and includes them in the `#allScalars` output.

The real KSP build calls `Context.resolve()` (in `ImmutableProcessor`/`DtoProcessor`), which is why the actual build output correctly excludes `@IdView` properties. The Java (APT) path is unaffected because jimmer-apt's `getIdViewBaseProp()` resolves lazily on demand.

## Changes

- `JimmerBuddy.kt` `dtoProcessKotlin`: call `option.context.resolve()` after `typeOf()` and before `compiler.compile()`
- `DtoInspection.kt` Kotlin branch: call `context.resolve()` for consistency