### PR TITLE
fix(#213): 修复未收录注解触发的 ClassCastException

### DIFF
--- a/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/apt.kt
+++ b/core/src/main/kotlin/cn/enaium/jimmer/buddy/utility/apt.kt
@@ -41,6 +41,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.io.Writer
+import java.lang.reflect.Proxy
 import java.util.*
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
@@ -773,6 +774,30 @@ private fun PsiAnnotation.findAnnotation(): Annotation? = when (qualifiedName) {
         }.newInstance() as Annotation
 } ?: run {
     val qualifiedName = qualifiedName?.takeIf { !it.startsWith("java.") } ?: return null
+
+    // Resolve against the plugin classloader, which sees the bundled jimmer jars;
+    // the PsiAnnotation's own loader cannot, and a proxy implementing the genuine
+    // annotation interface is the only thing callers' casts will accept.
+    val realClass = runCatching {
+        Class.forName(qualifiedName, false, Utility::class.java.classLoader)
+    }.getOrNull()?.takeIf { it.isAnnotation }
+    if (realClass != null) {
+        return Proxy.newProxyInstance(Utility::class.java.classLoader, arrayOf(realClass)) { proxy, method, args ->
+            when {
+                method.declaringClass == Any::class.java -> when (method.name) {
+                    "equals" -> proxy === args?.getOrNull(0)
+                    "hashCode" -> qualifiedName.hashCode()
+                    else -> "@$qualifiedName"
+                }
+
+                method.name == "annotationType" -> realClass
+                else -> this@findAnnotation.findAttributeValue(method.name)?.toAny(method.returnType)
+                    ?.arrayWrapper(method.returnType)
+                    ?: method.defaultValue
+            }
+        } as Annotation
+    }
+
     val map = mutableMapOf<String, ByteArray>()
 
     class MyClassLoader : ClassLoader(this.javaClass.classLoader) {


### PR DESCRIPTION
findAnnotation 白名单外的注解（如 @Default、@DatabaseDefault 等）原先由 ByteBuddy 合成仅实现 Annotation 的假代理，jimmer-apt 强转回真实注解接口时 抛 ClassCastException。改为先用插件 classloader 加载真实注解类，成功则以 JDK 动态代理实现真实接口（属性值取自 PSI，缺省回退注解声明的默认值），
加载不到才退回原合成路径。